### PR TITLE
Update Dataframes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 IPNets
-DataFrames 0.9.0 0.11.0
+DataFrames 0.11.0
 ZipFile 0.2.4
 Requests 0.2.4
 GZip

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.6
 IPNets
 DataFrames 0.11.0
+CSV
 ZipFile 0.2.4
 Requests 0.2.4
 GZip

--- a/src/geoip-module.jl
+++ b/src/geoip-module.jl
@@ -9,8 +9,8 @@ struct Location <: Point3D
     datum::String
 
     function Location(x,y,z=0, datum="WGS84")
-        if x === NA || y === NA
-            return NA
+        if x === missing || y === missing
+            return missing
         else
             return new(x,y,z,datum)
         end


### PR DESCRIPTION
Fixes #23. Uses `CSV.read` to replace the, now deprecated, `DataFrames.readtable`.