### PR TITLE
Fix name occurences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoIP"
 uuid = "abcde121-99a1-4d4f-92c5-2a3c6888d26a"
 authors = ["Andrey Oskin", "Seth Bromberger", "contributors: https://github.com/JuliaWeb/GeoIP.jl/graphs/contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/data.jl
+++ b/src/data.jl
@@ -54,10 +54,10 @@ function loadzip(datadir, zipfile)
     local locs
     try
         for f in r.files
-            if f.name == "GeoLite2-City-Locations-en.csv"
+            if occursin("GeoLite2-City-Locations-en.csv", f.name)
                 v = Vector{UInt8}(undef, f.uncompressedsize)
                 locs = read!(f, v) |> CSV.File |> DataFrame
-            elseif f.name == "GeoLite2-City-Blocks-IPv4.csv"
+            elseif occursin("GeoLite2-City-Blocks-IPv4.csv", f.name)
                 v = Vector{UInt8}(undef, f.uncompressedsize)
                 blocks = read!(f, v) |> CSV.File |> DataFrame
             end


### PR DESCRIPTION
It turns out that MaxMind db stores data in a directory, so naive equality fails.