### PR TITLE
Updated geolocate speed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoIP"
 uuid = "abcde121-99a1-4d4f-92c5-2a3c6888d26a"
 authors = ["Andrey Oskin", "Seth Bromberger", "contributors: https://github.com/JuliaWeb/GeoIP.jl/graphs/contributors"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/data.jl
+++ b/src/data.jl
@@ -86,7 +86,7 @@ function loadgz(datadir, blockcsvgz, citycsvgz)
     local locs
     try
         blocks = GZip.open(blockfile, "r") do stream
-            CSV.File(read(stream))
+            CSV.File(read(stream); types = Dict(:postal_code => String))
         end
         locs = GZip.open(locfile, "r") do stream
             CSV.File(read(stream))
@@ -113,7 +113,7 @@ function loadzip(datadir, zipfile)
                 locs = read!(f, v) |> CSV.File
             elseif occursin("City-Blocks-IPv4.csv", f.name)
                 v = Vector{UInt8}(undef, f.uncompressedsize)
-                blocks = read!(f, v) |> CSV.File
+                blocks = read!(f, v) |> x -> CSV.File(x; types = Dict(:postal_code => String))
             end
         end
     catch

--- a/src/data.jl
+++ b/src/data.jl
@@ -13,7 +13,7 @@ struct Location <: Point3D
 
     function Location(x, y, z = 0, datum = "WGS84")
         if x === missing || y === missing
-            return new(0, 0, 0, datum)
+            return missing
         else
             return new(x, y, z, datum)
         end
@@ -33,23 +33,23 @@ end
 Base.broadcastable(db::DB) = Ref(db)
 
 struct BlockRow{T}
-    net::T
+    v4net::T
     geoname_id::Int
-    location::Location
-    registered_country_geoname_id::Int
+    location::Union{Location, Missing}
+    registered_country_geoname_id::Union{Int, Missing}
     is_anonymous_proxy::Int
     is_satellite_provider::Int
-    postal_code::String
-    accuracy_radius::Int
+    postal_code::Union{String, Missing}
+    accuracy_radius::Union{Int, Missing}
 end
 
 function BlockRow(csvrow)
     net = IPNets.IPv4Net(csvrow.network)
     geoname_id = ismissing(csvrow.geoname_id) ? -1 : csvrow.geoname_id
     location = Location(csvrow.longitude, csvrow.latitude)
-    registered_country_geoname_id = ismissing(csvrow.registered_country_geoname_id) ? -1 : csvrow.registered_country_geoname_id
-    accuracy_radius = ismissing(csvrow.accuracy_radius) ? -1 : csvrow.accuracy_radius
-    postal_code = ismissing(csvrow.postal_code) ? "" : csvrow.postal_code
+    registered_country_geoname_id = csvrow.registered_country_geoname_id
+    accuracy_radius = get(csvrow, :accuracy_radius, missing)
+    postal_code = csvrow.postal_code
 
     BlockRow(
         net,
@@ -108,10 +108,10 @@ function loadzip(datadir, zipfile)
     local locs
     try
         for f in r.files
-            if occursin("GeoLite2-City-Locations-en.csv", f.name)
+            if occursin("City-Locations-en.csv", f.name)
                 v = Vector{UInt8}(undef, f.uncompressedsize)
                 locs = read!(f, v) |> CSV.File
-            elseif occursin("GeoLite2-City-Blocks-IPv4.csv", f.name)
+            elseif occursin("City-Blocks-IPv4.csv", f.name)
                 v = Vector{UInt8}(undef, f.uncompressedsize)
                 blocks = read!(f, v) |> CSV.File
             end
@@ -143,36 +143,12 @@ function load(; zipfile = "",
         loadzip(datadir, zipfile)
     end
 
-    # TODO: All of this is slow and should be improved. No DataFrame is needed actually
-    # Clean up unneeded columns and map others to appropriate data structures
     blockdb = BlockRow.(blocks)
-    sort!(blockdb, by = x -> x.net)
-    index = map(x -> x.net, blockdb)
+    sort!(blockdb, by = x -> x.v4net)
+    index = map(x -> x.v4net, blockdb)
     locsdb = collect(locs)
     sort!(locsdb, by = x -> x.geoname_id)
     locindex = map(x -> x.geoname_id, locsdb)
 
     return DB(index, locindex, blockdb, locsdb)
-
-    # return blocks[1:100]
-
-    # select!(blocks, Not([:represented_country_geoname_id, :is_anonymous_proxy, :is_satellite_provider]))
-
-    # blocks[!, :v4net] = map(x -> IPNets.IPv4Net(x), blocks[!, :network])
-    # select!(blocks, Not(:network))
-
-    # blocks[!, :location] = map(Location, blocks[!, :longitude], blocks[!, :latitude])
-    # select!(blocks, Not([:longitude, :latitude]))
-    # blocks.geoname_id = map(x -> ismissing(x) ? -1 : Int(x), blocks.geoname_id)
-
-    # alldata = leftjoin(blocks, locs, on = :geoname_id)
-
-    # df = sort!(alldata, :v4net)
-    # db = Vector{Dict{String, Any}}(undef, size(df, 1))
-    # for i in axes(df, 1)
-    #     row = df[i, :]
-    #     db[i] = Dict(collect(zip(names(row), row)))
-    # end
-
-    # return DB(df.v4net, db)
 end

--- a/src/geoip-module.jl
+++ b/src/geoip-module.jl
@@ -32,24 +32,16 @@ function geolocate(geodata::DB, ip::IPv4)
     ipnet = IPv4Net(ip, 32)
     db = geodata.db
 
-    # only iterate over rows that actually make sense - this filter is
-    # less expensive than iteration with in().
-    found = 0
-    for i in axes(db, 1)        # iterate over rows
-        if db[i, :v4net] > ipnet
-            found = i - 1
-            break
-        end
-    end
+    idx = searchsortedfirst(geodata.index, ipnet) - 1
 
     # TODO: sentinel value should be returned
-    retdict = Dict{String, Any}()
-    if (found > 0) && ip in db[found, :v4net]
-        # Placeholder, should be removed
-        row = db[found, :]
-        return Dict(collect(zip(names(row), row)))
+    res = if idx > 0 && ip in geodata.index[idx]
+        db[idx]
+    else
+        Dict{String, Any}()
     end
-    return retdict
+
+    return res
 end
 
 geolocate(geodata::DB, ipstr::AbstractString) = geolocate(geodata, IPv4(ipstr))

--- a/src/geoip-module.jl
+++ b/src/geoip-module.jl
@@ -18,7 +18,7 @@ function geolocate(geodata::DB, ip::IPv4)
     end
     row = geodata.blocks[idx]
 
-    res["net"] = row.net
+    res["v4net"] = row.v4net
     res["geoname_id"] = row.geoname_id
     res["location"] = row.location
     res["registered_country_geoname_id"] = row.registered_country_geoname_id


### PR DESCRIPTION
Closes #52 

With this PR, speed has improved significantly. `@btime` shows 27 ns which is 10^7 times faster than the current implementation.
Unfortunately, this comes at a cost of ~9Gb of `geodata` and almost a minute of data loading.

So, before merging, issues with extra memory occupation should be solved.